### PR TITLE
READMEの変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # nichinanhackathon.github.io
-日南ハッカソン×int のイベントページです
+イベントサイトのソースです。


### PR DESCRIPTION
検索エンジンに「日南ハッカソン×int のイベントページです - GitHub」と表示されて、紛らわしいため